### PR TITLE
Add support for older node versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-module.exports = x => {
+module.exports = function(x) {
 	if (typeof x !== 'string') {
 		throw new TypeError('Expected a string, got ' + typeof x);
 	}


### PR DESCRIPTION
Add support for older Node.js versions to avoid failures similar to

- https://travis-ci.org/steelbrain/intentions/jobs/150741259
- https://travis-ci.org/steelbrain/intentions/jobs/150741261

Both use APM's bundled Node.js versions that consumers can't easily change, changing this module is a good direction IMHO :)